### PR TITLE
Add new ESLint configuration

### DIFF
--- a/front-end/eslint.config.js
+++ b/front-end/eslint.config.js
@@ -1,23 +1,23 @@
-import js from "@eslint/js";
-import stylistic from "@stylistic/eslint-plugin";
-import typescriptParser from "@typescript-eslint/parser";
-import typescriptPlugin from "@typescript-eslint/eslint-plugin";
-import reactPlugin from "eslint-plugin-react";
-import globals from "globals";
+import js from '@eslint/js';
+import stylistic from '@stylistic/eslint-plugin';
+import typescriptParser from '@typescript-eslint/parser';
+import typescriptPlugin from '@typescript-eslint/eslint-plugin';
+import reactPlugin from 'eslint-plugin-react';
+import globals from 'globals';
 
 export default [
 	{
-		ignores: ["dist"],
+		ignores: ['dist'],
 	},
 	{
 		// All JavaScript-esque files
-		files: ["**/*.{m,c,}{js,ts}{x,}"],
+		files: ['**/*.{m,c,}{js,ts}{x,}'],
 		plugins: {
-			"@stylistic": stylistic,
+			'@stylistic': stylistic,
 		},
 		languageOptions: {
-			sourceType: "module",
-			ecmaVersion: "latest",
+			sourceType: 'module',
+			ecmaVersion: 'latest',
 			globals: {
 				...globals.node,
 				...globals.es2021, // es2022 is not available (https://github.com/sindresorhus/globals/issues/183)
@@ -27,43 +27,42 @@ export default [
 		rules: {
 			// Recommended
 			...js.configs.recommended.rules,
-			...stylistic.configs["recommended-flat"].rules,
+			...stylistic.configs['recommended-flat'].rules,
 
 			// Overrides
-			"@stylistic/indent": ["error", "tab"],
-			"@stylistic/indent-binary-ops": ["error", "tab"],
-			"@stylistic/no-tabs": 0,
-			"@stylistic/semi": ["error", "always"],
-			"@stylistic/member-delimiter-style": "error",
-			"@stylistic/quotes": "error",
+			'@stylistic/indent': ['error', 'tab'],
+			'@stylistic/indent-binary-ops': ['error', 'tab'],
+			'@stylistic/no-tabs': 0,
+			'@stylistic/semi': ['error', 'always'],
+			'@stylistic/member-delimiter-style': 'error',
 
 			// Additions
-			"curly": "error",
-			"no-shadow": "error",
-			"no-var": "error",
-			"prefer-const": "error",
+			'curly': 'error',
+			'no-shadow': 'error',
+			'no-var': 'error',
+			'prefer-const': 'error',
 		},
 	},
 	{
 		// TypeScript files
-		files: ["**/*.{m,c,}ts{x,}"],
+		files: ['**/*.{m,c,}ts{x,}'],
 		plugins: {
-			"@typescript-eslint": typescriptPlugin,
+			'@typescript-eslint': typescriptPlugin,
 		},
 		languageOptions: {
 			parser: typescriptParser,
 			parserOptions: {
-				project: "./tsconfig.eslint.json",
+				project: './tsconfig.eslint.json',
 			},
 		},
 		rules: {
-			...typescriptPlugin.configs["strict-type-checked"].rules,
-			...typescriptPlugin.configs["stylistic-type-checked"].rules,
+			...typescriptPlugin.configs['strict-type-checked'].rules,
+			...typescriptPlugin.configs['stylistic-type-checked'].rules,
 		},
 	},
 	{
 		// React files
-		files: ["**/*.{m,c,}{js,ts}x"],
+		files: ['**/*.{m,c,}{js,ts}x'],
 		plugins: {
 			react: reactPlugin,
 		},
@@ -79,17 +78,17 @@ export default [
 		},
 		settings: {
 			react: {
-				version: "detect",
+				version: 'detect',
 			},
 		},
 		rules: {
 			// Recommended
 			...reactPlugin.configs.recommended.rules,
-			...reactPlugin.configs["jsx-runtime"].rules,
+			...reactPlugin.configs['jsx-runtime'].rules,
 
 			// Overrides
-			"@stylistic/jsx-indent": ["error", "tab"],
-			"@stylistic/jsx-indent-props": ["error", "tab"],
+			'@stylistic/jsx-indent': ['error', 'tab'],
+			'@stylistic/jsx-indent-props': ['error', 'tab'],
 		},
 	},
 ];

--- a/front-end/eslint.config.js
+++ b/front-end/eslint.config.js
@@ -1,62 +1,52 @@
 import js from "@eslint/js";
+import stylistic from "@stylistic/eslint-plugin";
 import typescriptParser from "@typescript-eslint/parser";
 import typescriptPlugin from "@typescript-eslint/eslint-plugin";
+import reactPlugin from "eslint-plugin-react";
 import globals from "globals";
 
 export default [
 	{
-		ignores: ["node_modules", "dist"],
+		ignores: ["dist"],
 	},
 	{
-		files: ["**/*"],
+		// All JavaScript-esque files
+		files: ["**/*.{m,c,}{js,ts}{x,}"],
+		plugins: {
+			"@stylistic": stylistic,
+		},
 		languageOptions: {
 			sourceType: "module",
-			ecmaVersion: 2020,
+			ecmaVersion: "latest",
 			globals: {
-				...globals.browser,
-				...globals.es2020,
+				...globals.node,
+				...globals.es2021, // es2022 is not available (https://github.com/sindresorhus/globals/issues/183)
+				NodeJS: true,
 			},
 		},
 		rules: {
 			// Recommended
 			...js.configs.recommended.rules,
+			...stylistic.configs["recommended-flat"].rules,
 
-			// Defaults
-			"array-bracket-spacing": "error",
-			"arrow-spacing": "error",
-			"comma-spacing": "error",
-			"comma-style": "error",
+			// Overrides
+			"@stylistic/indent": ["error", "tab"],
+			"@stylistic/indent-binary-ops": ["error", "tab"],
+			"@stylistic/no-tabs": 0,
+			"@stylistic/semi": ["error", "always"],
+			"@stylistic/member-delimiter-style": "error",
+			"@stylistic/quotes": "error",
+
+			// Additions
 			"curly": "error",
-			"eol-last": "error",
-			"keyword-spacing": "error",
-			"max-statements-per-line": "error",
-			"no-floating-decimal": "error",
-			"no-inline-comments": "error",
-			"no-multi-spaces": "error",
-			"no-multiple-empty-lines": "error",
 			"no-shadow": "error",
-			"no-trailing-spaces": "error",
 			"no-var": "error",
 			"prefer-const": "error",
-			"quotes": "error",
-			"semi": "error",
-			"space-before-blocks": "error",
-			"space-before-function-paren": "error",
-			"space-in-parens": "error",
-			"space-infix-ops": "error",
-			"space-unary-ops": "error",
-			"spaced-comment": "error",
-
-			// Custom
-			"brace-style": ["error", "stroustrup"],
-			"comma-dangle": ["error", "always-multiline"],
-			"dot-location": ["error", "property"],
-			"indent": ["error", "tab"],
-			"object-curly-spacing": ["error", "always"],
 		},
 	},
 	{
-		files: ["**/*.ts", "**/*.tsx"],
+		// TypeScript files
+		files: ["**/*.{m,c,}ts{x,}"],
 		plugins: {
 			"@typescript-eslint": typescriptPlugin,
 		},
@@ -67,9 +57,39 @@ export default [
 			},
 		},
 		rules: {
-			...typescriptPlugin.configs["recommended-type-checked"].rules,
 			...typescriptPlugin.configs["strict-type-checked"].rules,
 			...typescriptPlugin.configs["stylistic-type-checked"].rules,
+		},
+	},
+	{
+		// React files
+		files: ["**/*.{m,c,}{js,ts}x"],
+		plugins: {
+			react: reactPlugin,
+		},
+		languageOptions: {
+			parserOptions: {
+				ecmaFeatures: {
+					jsx: true,
+				},
+			},
+			globals: {
+				...globals.browser,
+			},
+		},
+		settings: {
+			react: {
+				version: "detect",
+			},
+		},
+		rules: {
+			// Recommended
+			...reactPlugin.configs.recommended.rules,
+			...reactPlugin.configs["jsx-runtime"].rules,
+
+			// Overrides
+			"@stylistic/jsx-indent": ["error", "tab"],
+			"@stylistic/jsx-indent-props": ["error", "tab"],
 		},
 	},
 ];

--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -13,13 +13,15 @@
 				"web-vitals": "^3.5.0"
 			},
 			"devDependencies": {
+				"@stylistic/eslint-plugin": "^1.5.3",
 				"@types/node": "^20.10.3",
 				"@types/react": "^18.2.42",
 				"@types/react-dom": "^18.2.17",
-				"@typescript-eslint/eslint-plugin": "^6.13.2",
-				"@typescript-eslint/parser": "^6.13.2",
+				"@typescript-eslint/eslint-plugin": "^6.19.0",
+				"@typescript-eslint/parser": "^6.19.0",
 				"@vitejs/plugin-react-swc": "^3.5.0",
-				"eslint": "^8.55.0",
+				"eslint": "^8.56.0",
+				"eslint-plugin-react": "^7.33.2",
 				"typescript": "^5.2.2",
 				"vite": "^5.0.0",
 				"vitest": "^1.0.1"
@@ -434,9 +436,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.55.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.55.0.tgz",
-			"integrity": "sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+			"integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -690,6 +692,86 @@
 			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
 			"dev": true
 		},
+		"node_modules/@stylistic/eslint-plugin": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-1.5.3.tgz",
+			"integrity": "sha512-Vee+hHKaCd8DPRoRJTCV+mOFz+zFIaA9QiNJaAvgBzmPkcDnSC7Ewh518fN6SSNe9psS8TDIpcxd1g5v4MSY5A==",
+			"dev": true,
+			"dependencies": {
+				"@stylistic/eslint-plugin-js": "1.5.3",
+				"@stylistic/eslint-plugin-jsx": "1.5.3",
+				"@stylistic/eslint-plugin-plus": "1.5.3",
+				"@stylistic/eslint-plugin-ts": "1.5.3"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=8.40.0"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin-js": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.5.3.tgz",
+			"integrity": "sha512-XlKnm82fD7Sw9kQ6FFigE0tobvptNBXZWsdfoKmUyK7bNxHsAHOFT8zJGY3j3MjZ0Fe7rLTu86hX/vOl0bRRdQ==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.11.3",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-visitor-keys": "^3.4.3",
+				"espree": "^9.6.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=8.40.0"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin-jsx": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-1.5.3.tgz",
+			"integrity": "sha512-gKXWFmvg3B4e6G+bVz2p37icjj3gS5lzazZD6oLjmQ2b0Lw527VpnxGjWxQ16keKXtrVzUfebakjskOoALg3CQ==",
+			"dev": true,
+			"dependencies": {
+				"@stylistic/eslint-plugin-js": "^1.5.3",
+				"estraverse": "^5.3.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=8.40.0"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin-plus": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-1.5.3.tgz",
+			"integrity": "sha512-fuOBySbH4dbfY4Dwvu+zg5y+e0lALHTyQske5+a2zNC8Ejnx4rFlVjYOmaVFtxFhTD4V0vM7o21Ozci0igcxKg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/utils": "^6.17.0"
+			},
+			"peerDependencies": {
+				"eslint": "*"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin-ts": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-1.5.3.tgz",
+			"integrity": "sha512-/gUEqGo0gpFeu220YmC0788VliKnmTaAz4pI82KA5cUuCp6OzEhGlrNkb1eevMwH0RRgyND20HJxOYvEGlwu+w==",
+			"dev": true,
+			"dependencies": {
+				"@stylistic/eslint-plugin-js": "1.5.3",
+				"@typescript-eslint/utils": "^6.17.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=8.40.0"
+			}
+		},
 		"node_modules/@swc/core": {
 			"version": "1.3.100",
 			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.100.tgz",
@@ -937,16 +1019,16 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "6.13.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.13.2.tgz",
-			"integrity": "sha512-3+9OGAWHhk4O1LlcwLBONbdXsAhLjyCFogJY/cWy2lxdVJ2JrcTF2pTGMaLl2AE7U1l31n8Py4a8bx5DLf/0dQ==",
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.19.0.tgz",
+			"integrity": "sha512-DUCUkQNklCQYnrBSSikjVChdc84/vMPDQSgJTHBZ64G9bA9w0Crc0rd2diujKbTdp6w2J47qkeHQLoi0rpLCdg==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "6.13.2",
-				"@typescript-eslint/type-utils": "6.13.2",
-				"@typescript-eslint/utils": "6.13.2",
-				"@typescript-eslint/visitor-keys": "6.13.2",
+				"@typescript-eslint/scope-manager": "6.19.0",
+				"@typescript-eslint/type-utils": "6.19.0",
+				"@typescript-eslint/utils": "6.19.0",
+				"@typescript-eslint/visitor-keys": "6.19.0",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.4",
@@ -972,15 +1054,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "6.13.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.13.2.tgz",
-			"integrity": "sha512-MUkcC+7Wt/QOGeVlM8aGGJZy1XV5YKjTpq9jK6r6/iLsGXhBVaGP5N0UYvFsu9BFlSpwY9kMretzdBH01rkRXg==",
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.19.0.tgz",
+			"integrity": "sha512-1DyBLG5SH7PYCd00QlroiW60YJ4rWMuUGa/JBV0iZuqi4l4IK3twKPq5ZkEebmGqRjXWVgsUzfd3+nZveewgow==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.13.2",
-				"@typescript-eslint/types": "6.13.2",
-				"@typescript-eslint/typescript-estree": "6.13.2",
-				"@typescript-eslint/visitor-keys": "6.13.2",
+				"@typescript-eslint/scope-manager": "6.19.0",
+				"@typescript-eslint/types": "6.19.0",
+				"@typescript-eslint/typescript-estree": "6.19.0",
+				"@typescript-eslint/visitor-keys": "6.19.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -1000,13 +1082,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.13.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.13.2.tgz",
-			"integrity": "sha512-CXQA0xo7z6x13FeDYCgBkjWzNqzBn8RXaE3QVQVIUm74fWJLkJkaHmHdKStrxQllGh6Q4eUGyNpMe0b1hMkXFA==",
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.19.0.tgz",
+			"integrity": "sha512-dO1XMhV2ehBI6QN8Ufi7I10wmUovmLU0Oru3n5LVlM2JuzB4M+dVphCPLkVpKvGij2j/pHBWuJ9piuXx+BhzxQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.13.2",
-				"@typescript-eslint/visitor-keys": "6.13.2"
+				"@typescript-eslint/types": "6.19.0",
+				"@typescript-eslint/visitor-keys": "6.19.0"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -1017,13 +1099,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.13.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.13.2.tgz",
-			"integrity": "sha512-Qr6ssS1GFongzH2qfnWKkAQmMUyZSyOr0W54nZNU1MDfo+U4Mv3XveeLZzadc/yq8iYhQZHYT+eoXJqnACM1tw==",
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.19.0.tgz",
+			"integrity": "sha512-mcvS6WSWbjiSxKCwBcXtOM5pRkPQ6kcDds/juxcy/727IQr3xMEcwr/YLHW2A2+Fp5ql6khjbKBzOyjuPqGi/w==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.13.2",
-				"@typescript-eslint/utils": "6.13.2",
+				"@typescript-eslint/typescript-estree": "6.19.0",
+				"@typescript-eslint/utils": "6.19.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -1044,9 +1126,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.13.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.13.2.tgz",
-			"integrity": "sha512-7sxbQ+EMRubQc3wTfTsycgYpSujyVbI1xw+3UMRUcrhSy+pN09y/lWzeKDbvhoqcRbHdc+APLs/PWYi/cisLPg==",
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.19.0.tgz",
+			"integrity": "sha512-lFviGV/vYhOy3m8BJ/nAKoAyNhInTdXpftonhWle66XHAtT1ouBlkjL496b5H5hb8dWXHwtypTqgtb/DEa+j5A==",
 			"dev": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -1057,16 +1139,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.13.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.13.2.tgz",
-			"integrity": "sha512-SuD8YLQv6WHnOEtKv8D6HZUzOub855cfPnPMKvdM/Bh1plv1f7Q/0iFUDLKKlxHcEstQnaUU4QZskgQq74t+3w==",
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.19.0.tgz",
+			"integrity": "sha512-o/zefXIbbLBZ8YJ51NlkSAt2BamrK6XOmuxSR3hynMIzzyMY33KuJ9vuMdFSXW+H0tVvdF9qBPTHA91HDb4BIQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.13.2",
-				"@typescript-eslint/visitor-keys": "6.13.2",
+				"@typescript-eslint/types": "6.19.0",
+				"@typescript-eslint/visitor-keys": "6.19.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
+				"minimatch": "9.0.3",
 				"semver": "^7.5.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -1083,18 +1166,42 @@
 				}
 			}
 		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "6.13.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.13.2.tgz",
-			"integrity": "sha512-b9Ptq4eAZUym4idijCRzl61oPCwwREcfDI8xGk751Vhzig5fFZR9CyzDz4Sp/nxSLBYxUPyh4QdIDqWykFhNmQ==",
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.19.0.tgz",
+			"integrity": "sha512-QR41YXySiuN++/dC9UArYOg4X86OAYP83OWTewpVx5ct1IZhjjgTLocj7QNxGhWoTqknsgpl7L+hGygCO+sdYw==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
 				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.13.2",
-				"@typescript-eslint/types": "6.13.2",
-				"@typescript-eslint/typescript-estree": "6.13.2",
+				"@typescript-eslint/scope-manager": "6.19.0",
+				"@typescript-eslint/types": "6.19.0",
+				"@typescript-eslint/typescript-estree": "6.19.0",
 				"semver": "^7.5.4"
 			},
 			"engines": {
@@ -1109,12 +1216,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.13.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.13.2.tgz",
-			"integrity": "sha512-OGznFs0eAQXJsp+xSd6k/O1UbFi/K/L7WjqeRoFE7vadjAF9y0uppXhYNQNEqygjou782maGClOoZwPqF0Drlw==",
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.19.0.tgz",
+			"integrity": "sha512-hZaUCORLgubBvtGpp1JEFEazcuEdfxta9j4iUwdSAr7mEsYYAp3EAUyCZk3VEEqGj6W+AV4uWyrDGtrlawAsgQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.13.2",
+				"@typescript-eslint/types": "6.19.0",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -1239,9 +1346,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.11.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-			"integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+			"version": "8.11.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -1314,6 +1421,38 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
+		"node_modules/array-buffer-byte-length": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+			"integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"is-array-buffer": "^3.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array-includes": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.7.tgz",
+			"integrity": "sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"get-intrinsic": "^1.2.1",
+				"is-string": "^1.0.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -1323,6 +1462,76 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/array.prototype.flat": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
+			"integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"es-shim-unscopables": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.flatmap": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
+			"integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"es-shim-unscopables": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.tosorted": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.2.tgz",
+			"integrity": "sha512-HuQCHOlk1Weat5jzStICBCd83NxiIMwqDg/dHEsoefabn/hJRj5pVdWcPUSpRrwhwxZOsQassMpgN/xRYFBMIg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"es-shim-unscopables": "^1.0.0",
+				"get-intrinsic": "^1.2.1"
+			}
+		},
+		"node_modules/arraybuffer.prototype.slice": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
+			"integrity": "sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==",
+			"dev": true,
+			"dependencies": {
+				"array-buffer-byte-length": "^1.0.0",
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"get-intrinsic": "^1.2.1",
+				"is-array-buffer": "^3.0.2",
+				"is-shared-array-buffer": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -1330,6 +1539,27 @@
 			"dev": true,
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/asynciterator.prototype": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/asynciterator.prototype/-/asynciterator.prototype-1.0.0.tgz",
+			"integrity": "sha512-wwHYEIS0Q80f5mosx3L/dfG5t5rjEa9Ft51GTaNt862EnpyGHpgz2RkZvLPp1oF5TnAiTohkEKVEu8pQPJI7Vg==",
+			"dev": true,
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			}
+		},
+		"node_modules/available-typed-arrays": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -1367,6 +1597,20 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/call-bind": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+			"integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.1",
+				"set-function-length": "^1.1.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/callsites": {
@@ -1503,6 +1747,37 @@
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
 		},
+		"node_modules/define-data-property": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+			"integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.2.1",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/define-properties": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.0.1",
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/diff-sequences": {
 			"version": "29.6.3",
 			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -1534,6 +1809,121 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/es-abstract": {
+			"version": "1.22.3",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.3.tgz",
+			"integrity": "sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==",
+			"dev": true,
+			"dependencies": {
+				"array-buffer-byte-length": "^1.0.0",
+				"arraybuffer.prototype.slice": "^1.0.2",
+				"available-typed-arrays": "^1.0.5",
+				"call-bind": "^1.0.5",
+				"es-set-tostringtag": "^2.0.1",
+				"es-to-primitive": "^1.2.1",
+				"function.prototype.name": "^1.1.6",
+				"get-intrinsic": "^1.2.2",
+				"get-symbol-description": "^1.0.0",
+				"globalthis": "^1.0.3",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.0",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0",
+				"internal-slot": "^1.0.5",
+				"is-array-buffer": "^3.0.2",
+				"is-callable": "^1.2.7",
+				"is-negative-zero": "^2.0.2",
+				"is-regex": "^1.1.4",
+				"is-shared-array-buffer": "^1.0.2",
+				"is-string": "^1.0.7",
+				"is-typed-array": "^1.1.12",
+				"is-weakref": "^1.0.2",
+				"object-inspect": "^1.13.1",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.4",
+				"regexp.prototype.flags": "^1.5.1",
+				"safe-array-concat": "^1.0.1",
+				"safe-regex-test": "^1.0.0",
+				"string.prototype.trim": "^1.2.8",
+				"string.prototype.trimend": "^1.0.7",
+				"string.prototype.trimstart": "^1.0.7",
+				"typed-array-buffer": "^1.0.0",
+				"typed-array-byte-length": "^1.0.0",
+				"typed-array-byte-offset": "^1.0.0",
+				"typed-array-length": "^1.0.4",
+				"unbox-primitive": "^1.0.2",
+				"which-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/es-iterator-helpers": {
+			"version": "1.0.15",
+			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.15.tgz",
+			"integrity": "sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==",
+			"dev": true,
+			"dependencies": {
+				"asynciterator.prototype": "^1.0.0",
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.22.1",
+				"es-set-tostringtag": "^2.0.1",
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.2.1",
+				"globalthis": "^1.0.3",
+				"has-property-descriptors": "^1.0.0",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"internal-slot": "^1.0.5",
+				"iterator.prototype": "^1.1.2",
+				"safe-array-concat": "^1.0.1"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
+			"integrity": "sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.2.2",
+				"has-tostringtag": "^1.0.0",
+				"hasown": "^2.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-shim-unscopables": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+			"integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
+			"dev": true,
+			"dependencies": {
+				"hasown": "^2.0.0"
+			}
+		},
+		"node_modules/es-to-primitive": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+			"dev": true,
+			"dependencies": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/esbuild": {
@@ -1586,15 +1976,15 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.55.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.55.0.tgz",
-			"integrity": "sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+			"integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
 				"@eslint/eslintrc": "^2.1.4",
-				"@eslint/js": "8.55.0",
+				"@eslint/js": "8.56.0",
 				"@humanwhocodes/config-array": "^0.11.13",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
@@ -1638,6 +2028,57 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-plugin-react": {
+			"version": "7.33.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.33.2.tgz",
+			"integrity": "sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==",
+			"dev": true,
+			"dependencies": {
+				"array-includes": "^3.1.6",
+				"array.prototype.flatmap": "^1.3.1",
+				"array.prototype.tosorted": "^1.1.1",
+				"doctrine": "^2.1.0",
+				"es-iterator-helpers": "^1.0.12",
+				"estraverse": "^5.3.0",
+				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
+				"minimatch": "^3.1.2",
+				"object.entries": "^1.1.6",
+				"object.fromentries": "^2.0.6",
+				"object.hasown": "^1.1.2",
+				"object.values": "^1.1.6",
+				"prop-types": "^15.8.1",
+				"resolve": "^2.0.0-next.4",
+				"semver": "^6.3.1",
+				"string.prototype.matchall": "^4.0.8"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"peerDependencies": {
+				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+			}
+		},
+		"node_modules/eslint-plugin-react/node_modules/doctrine": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/eslint-plugin-react/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -1865,6 +2306,15 @@
 			"integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
 			"dev": true
 		},
+		"node_modules/for-each": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+			"dev": true,
+			"dependencies": {
+				"is-callable": "^1.1.3"
+			}
+		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1885,6 +2335,42 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/function.prototype.name": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+			"integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"functions-have-names": "^1.2.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/functions-have-names": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/get-func-name": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
@@ -1892,6 +2378,21 @@
 			"dev": true,
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+			"integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.2",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/get-stream": {
@@ -1904,6 +2405,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-symbol-description": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+			"integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/glob": {
@@ -1953,6 +2470,21 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/globalthis": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+			"integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+			"dev": true,
+			"dependencies": {
+				"define-properties": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/globby": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -1973,11 +2505,32 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/gopd": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.1.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
+		},
+		"node_modules/has-bigints": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
@@ -1986,6 +2539,69 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+			"integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.2.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+			"dev": true,
+			"dependencies": {
+				"has-symbols": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+			"integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/human-signals": {
@@ -2047,6 +2663,116 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
+		"node_modules/internal-slot": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
+			"integrity": "sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.2.2",
+				"hasown": "^2.0.0",
+				"side-channel": "^1.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/is-array-buffer": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+			"integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.2.0",
+				"is-typed-array": "^1.1.10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-async-function": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
+			"integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-bigint": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+			"dev": true,
+			"dependencies": {
+				"has-bigints": "^1.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-boolean-object": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-core-module": {
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+			"integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+			"dev": true,
+			"dependencies": {
+				"hasown": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-date-object": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2054,6 +2780,33 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-finalizationregistry": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.0.2.tgz",
+			"integrity": "sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-generator-function": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+			"integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-glob": {
@@ -2068,6 +2821,27 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-map": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+			"integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-negative-zero": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+			"integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2077,6 +2851,21 @@
 				"node": ">=0.12.0"
 			}
 		},
+		"node_modules/is-number-object": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+			"integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-path-inside": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -2084,6 +2873,43 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/is-regex": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-set": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+			"integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-shared-array-buffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+			"integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-stream": {
@@ -2098,11 +2924,109 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/is-string": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-symbol": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+			"dev": true,
+			"dependencies": {
+				"has-symbols": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-typed-array": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+			"integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+			"dev": true,
+			"dependencies": {
+				"which-typed-array": "^1.1.11"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-weakmap": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+			"integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-weakref": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-weakset": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+			"integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
+		},
+		"node_modules/iterator.prototype": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.2.tgz",
+			"integrity": "sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==",
+			"dev": true,
+			"dependencies": {
+				"define-properties": "^1.2.1",
+				"get-intrinsic": "^1.2.1",
+				"has-symbols": "^1.0.3",
+				"reflect.getprototypeof": "^1.0.4",
+				"set-function-name": "^2.0.1"
+			}
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
@@ -2144,6 +3068,21 @@
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
 			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
 			"dev": true
+		},
+		"node_modules/jsx-ast-utils": {
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+			"integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+			"dev": true,
+			"dependencies": {
+				"array-includes": "^3.1.6",
+				"array.prototype.flat": "^1.3.1",
+				"object.assign": "^4.1.4",
+				"object.values": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
 		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
@@ -2369,6 +3308,112 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/object.assign": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+			"integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
+				"has-symbols": "^1.0.3",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object.entries": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.7.tgz",
+			"integrity": "sha512-jCBs/0plmPsOnrKAfFQXRG2NFjlhZgjjcBLSmTnEhU8U6vVTsVe8ANeQJCHTl3gSsI4J+0emOoCgoKlmQPMgmA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/object.fromentries": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.7.tgz",
+			"integrity": "sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object.hasown": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.3.tgz",
+			"integrity": "sha512-fFI4VcYpRHvSLXxP7yiZOMAd331cPfd2p7PFDVbgUsYOfCT3tICVqXWngbjr4m49OvsBwUBQ6O2uQoJvy3RexA==",
+			"dev": true,
+			"dependencies": {
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object.values": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.7.tgz",
+			"integrity": "sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2478,6 +3523,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
@@ -2595,6 +3646,23 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/prop-types": {
+			"version": "15.8.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+			"dev": true,
+			"dependencies": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.13.1"
+			}
+		},
+		"node_modules/prop-types/node_modules/react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"dev": true
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2652,6 +3720,60 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
 			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
 			"dev": true
+		},
+		"node_modules/reflect.getprototypeof": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
+			"integrity": "sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"get-intrinsic": "^1.2.1",
+				"globalthis": "^1.0.3",
+				"which-builtin-type": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/regexp.prototype.flags": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
+			"integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"set-function-name": "^2.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/resolve": {
+			"version": "2.0.0-next.5",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+			"integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+			"dev": true,
+			"dependencies": {
+				"is-core-module": "^2.13.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
@@ -2738,6 +3860,41 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"node_modules/safe-array-concat": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
+			"integrity": "sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.5",
+				"get-intrinsic": "^1.2.2",
+				"has-symbols": "^1.0.3",
+				"isarray": "^2.0.5"
+			},
+			"engines": {
+				"node": ">=0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/safe-regex-test": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.2.tgz",
+			"integrity": "sha512-83S9w6eFq12BBIJYvjMux6/dkirb8+4zJRA9cxNBVb7Wq5fJBW+Xze48WqR8pxua7bDuAaaAxtVVd4Idjp1dBQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.5",
+				"get-intrinsic": "^1.2.2",
+				"is-regex": "^1.1.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/scheduler": {
 			"version": "0.23.0",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
@@ -2761,6 +3918,36 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/set-function-length": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
+			"integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.2",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/set-function-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
+			"integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.0.1",
+				"functions-have-names": "^1.2.3",
+				"has-property-descriptors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2780,6 +3967,20 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.0",
+				"get-intrinsic": "^1.0.2",
+				"object-inspect": "^1.9.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/siginfo": {
@@ -2829,6 +4030,71 @@
 			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.6.0.tgz",
 			"integrity": "sha512-aFZ19IgVmhdB2uX599ve2kE6BIE3YMnQ6Gp6BURhW/oIzpXGKr878TQfAQZn1+i0Flcc/UKUy1gOlcfaUBCryg==",
 			"dev": true
+		},
+		"node_modules/string.prototype.matchall": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.10.tgz",
+			"integrity": "sha512-rGXbGmOEosIQi6Qva94HUjgPs9vKW+dkG7Y8Q5O2OYkWL6wFaTRZO8zM4mhP94uX55wgyrXzfS2aGtGzUL7EJQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"get-intrinsic": "^1.2.1",
+				"has-symbols": "^1.0.3",
+				"internal-slot": "^1.0.5",
+				"regexp.prototype.flags": "^1.5.0",
+				"set-function-name": "^2.0.0",
+				"side-channel": "^1.0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.trim": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
+			"integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.trimend": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
+			"integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.trimstart": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
+			"integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
@@ -2888,6 +4154,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/text-table": {
@@ -2977,6 +4255,71 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/typed-array-buffer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
+			"integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.2.1",
+				"is-typed-array": "^1.1.10"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/typed-array-byte-length": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
+			"integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"for-each": "^0.3.3",
+				"has-proto": "^1.0.1",
+				"is-typed-array": "^1.1.10"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/typed-array-byte-offset": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
+			"integrity": "sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==",
+			"dev": true,
+			"dependencies": {
+				"available-typed-arrays": "^1.0.5",
+				"call-bind": "^1.0.2",
+				"for-each": "^0.3.3",
+				"has-proto": "^1.0.1",
+				"is-typed-array": "^1.1.10"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/typed-array-length": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+			"integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"for-each": "^0.3.3",
+				"is-typed-array": "^1.1.9"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
@@ -2995,6 +4338,21 @@
 			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.2.tgz",
 			"integrity": "sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==",
 			"dev": true
+		},
+		"node_modules/unbox-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
+				"which-boxed-primitive": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/undici-types": {
 			"version": "5.26.5",
@@ -3172,6 +4530,82 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/which-boxed-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+			"dev": true,
+			"dependencies": {
+				"is-bigint": "^1.0.1",
+				"is-boolean-object": "^1.1.0",
+				"is-number-object": "^1.0.4",
+				"is-string": "^1.0.5",
+				"is-symbol": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-builtin-type": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.3.tgz",
+			"integrity": "sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==",
+			"dev": true,
+			"dependencies": {
+				"function.prototype.name": "^1.1.5",
+				"has-tostringtag": "^1.0.0",
+				"is-async-function": "^2.0.0",
+				"is-date-object": "^1.0.5",
+				"is-finalizationregistry": "^1.0.2",
+				"is-generator-function": "^1.0.10",
+				"is-regex": "^1.1.4",
+				"is-weakref": "^1.0.2",
+				"isarray": "^2.0.5",
+				"which-boxed-primitive": "^1.0.2",
+				"which-collection": "^1.0.1",
+				"which-typed-array": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-collection": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+			"integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+			"dev": true,
+			"dependencies": {
+				"is-map": "^2.0.1",
+				"is-set": "^2.0.1",
+				"is-weakmap": "^2.0.1",
+				"is-weakset": "^2.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-typed-array": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
+			"integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
+			"dev": true,
+			"dependencies": {
+				"available-typed-arrays": "^1.0.5",
+				"call-bind": "^1.0.4",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/why-is-node-running": {

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -17,13 +17,15 @@
 		"web-vitals": "^3.5.0"
 	},
 	"devDependencies": {
+		"@stylistic/eslint-plugin": "^1.5.3",
 		"@types/node": "^20.10.3",
 		"@types/react": "^18.2.42",
 		"@types/react-dom": "^18.2.17",
-		"@typescript-eslint/eslint-plugin": "^6.13.2",
-		"@typescript-eslint/parser": "^6.13.2",
+		"@typescript-eslint/eslint-plugin": "^6.19.0",
+		"@typescript-eslint/parser": "^6.19.0",
 		"@vitejs/plugin-react-swc": "^3.5.0",
-		"eslint": "^8.55.0",
+		"eslint": "^8.56.0",
+		"eslint-plugin-react": "^7.33.2",
 		"typescript": "^5.2.2",
 		"vite": "^5.0.0",
 		"vitest": "^1.0.1"

--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -11,7 +11,7 @@ import styles from "./App.module.css";
 const WEBSOCKET_URL = "ws://0.0.0.0:8000";
 const SERVER_URL = "http://0.0.0.0:8000";
 
-export function App () {
+export function App() {
 	const [listen, setListen] = useState(false);
 	const [listenSocket, setListenSocket] = useState<WebSocket | null>();
 	const [speakSocket, setSpeakSocket] = useState<WebSocket | null>(null);
@@ -21,8 +21,7 @@ export function App () {
 	const [audioURL, setAudioURL] = useState<string | null>(null);
 	const [messages, setMessages] = useState<Message[]>([]);
 
-
-	function doListen () {
+	function doListen() {
 		console.log("doListen");
 		if (!listenSocket) {
 			const socket = new WebSocket(WEBSOCKET_URL + "/transcribe");
@@ -36,7 +35,7 @@ export function App () {
 		}
 	}
 
-	function toggleListen () {
+	function toggleListen() {
 		console.log("toggleListen");
 		setListen(!listen);
 		setFirstMessage(true);
@@ -53,7 +52,7 @@ export function App () {
 				const transcriptionResult = event.data as string;
 				if (listen) {
 					// Functional update
-					setTranscription((prevTranscription) => prevTranscription + " " + transcriptionResult);
+					setTranscription(prevTranscription => prevTranscription + " " + transcriptionResult);
 					listenSocket.send("ACK");
 
 					setMessages((prevMessages) => {
@@ -100,15 +99,14 @@ export function App () {
 		}
 	}, [listen, transcription]);
 
-
-	async function generate (voiceInput: string): Promise<string[]> {
+	async function generate(voiceInput: string): Promise<string[]> {
 		const res = await fetch(`${SERVER_URL}/query`, {
 			method: "POST",
 			// Assuming the server expects an array of questions
 			body: JSON.stringify({ question: voiceInput }),
 			headers: {
 				"Content-Type": "application/json",
-				accept: "application/json",
+				"accept": "application/json",
 			},
 		});
 
@@ -117,20 +115,17 @@ export function App () {
 		return data;
 	}
 
-
 	const speak = () => {
-		setMessages((prevMessages) => [...prevMessages, { message: inputText, side: "right" }]);
+		setMessages(prevMessages => [...prevMessages, { message: inputText, side: "right" }]);
 		setInputText("");
 
 		// Store the socket reference for later use
 		if (!speakSocket) {
 			setSpeakSocket(new WebSocket(WEBSOCKET_URL + "/speak"));
 		}
-
 	};
 
 	useEffect(() => {
-
 		if (speakSocket) {
 			console.log("speakSocket");
 			speakSocket.onerror = function (event) {
@@ -184,9 +179,9 @@ export function App () {
 			<Listen listen={listen} toggleListen={toggleListen} />
 			<div className={styles.mainView}>
 				<Chat messages={messages} />
-				<Responses responses={responses} setInputText={setInputText}/>
+				<Responses responses={responses} setInputText={setInputText} />
 			</div>
-			<InputBar inputText={inputText} onInputChange={onInputChange} speak={speak} audioURL={audioURL}/>
+			<InputBar inputText={inputText} onInputChange={onInputChange} speak={speak} audioURL={audioURL} />
 		</div>
 	);
 }

--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -1,34 +1,34 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect } from 'react';
 
-import { Listen } from "./components/Listen.js";
-import { Chat } from "./components/Chat.js";
-import type { Message } from "./components/Chat.jsx";
-import { Responses } from "./components/Responses.js";
-import { InputBar } from "./components/InputBar.js";
+import { Listen } from './components/Listen.js';
+import { Chat } from './components/Chat.js';
+import type { Message } from './components/Chat.jsx';
+import { Responses } from './components/Responses.js';
+import { InputBar } from './components/InputBar.js';
 
-import styles from "./App.module.css";
+import styles from './App.module.css';
 
-const WEBSOCKET_URL = "ws://0.0.0.0:8000";
-const SERVER_URL = "http://0.0.0.0:8000";
+const WEBSOCKET_URL = 'ws://0.0.0.0:8000';
+const SERVER_URL = 'http://0.0.0.0:8000';
 
 export function App() {
 	const [listen, setListen] = useState(false);
 	const [listenSocket, setListenSocket] = useState<WebSocket | null>();
 	const [speakSocket, setSpeakSocket] = useState<WebSocket | null>(null);
-	const [transcription, setTranscription] = useState("");
+	const [transcription, setTranscription] = useState('');
 	const [firstMessage, setFirstMessage] = useState(true);
-	const [inputText, setInputText] = useState("");
+	const [inputText, setInputText] = useState('');
 	const [audioURL, setAudioURL] = useState<string | null>(null);
 	const [messages, setMessages] = useState<Message[]>([]);
 
 	function doListen() {
-		console.log("doListen");
+		console.log('doListen');
 		if (!listenSocket) {
-			const socket = new WebSocket(WEBSOCKET_URL + "/transcribe");
+			const socket = new WebSocket(WEBSOCKET_URL + '/transcribe');
 
 			socket.onerror = function (event) {
-				console.error("WebSocket error:", event);
-				alert("There was an error connecting to the transcription server");
+				console.error('WebSocket error:', event);
+				alert('There was an error connecting to the transcription server');
 			};
 
 			setListenSocket(socket);
@@ -36,7 +36,7 @@ export function App() {
 	}
 
 	function toggleListen() {
-		console.log("toggleListen");
+		console.log('toggleListen');
 		setListen(!listen);
 		setFirstMessage(true);
 		doListen();
@@ -44,97 +44,97 @@ export function App() {
 
 	useEffect(() => {
 		if (!listenSocket) {
-			console.log("no listenSocket");
+			console.log('no listenSocket');
 		}
 		else {
 			listenSocket.onmessage = (event) => {
-				console.log("listen: ", listen);
+				console.log('listen: ', listen);
 				const transcriptionResult = event.data as string;
 				if (listen) {
 					// Functional update
-					setTranscription(prevTranscription => prevTranscription + " " + transcriptionResult);
-					listenSocket.send("ACK");
+					setTranscription(prevTranscription => prevTranscription + ' ' + transcriptionResult);
+					listenSocket.send('ACK');
 
 					setMessages((prevMessages) => {
 						if (firstMessage) {
 							// Update firstMessage state
 							setFirstMessage(false);
-							return [...prevMessages, { message: transcriptionResult, side: "left" }];
+							return [...prevMessages, { message: transcriptionResult, side: 'left' }];
 						}
 						else {
 							return [
 								...prevMessages.slice(0, -1),
 								{
-									message: prevMessages[prevMessages.length - 1].message + " " + transcriptionResult,
-									side: "left",
+									message: prevMessages[prevMessages.length - 1].message + ' ' + transcriptionResult,
+									side: 'left',
 								},
 							];
 						}
 					});
 				}
 				else {
-					setTranscription("");
-					listenSocket.send("ACK");
+					setTranscription('');
+					listenSocket.send('ACK');
 				}
 			};
-			console.log("firstMessage: ", firstMessage);
+			console.log('firstMessage: ', firstMessage);
 		}
 	}, [listenSocket, firstMessage, listen]);
 	// Include firstMessage in dependency array
 
-	const [responses, setResponses] = useState(["", "", "", ""]);
+	const [responses, setResponses] = useState(['', '', '', '']);
 
 	useEffect(() => {
-		if (!listen && transcription != "") {
-			console.log("in generate");
+		if (!listen && transcription != '') {
+			console.log('in generate');
 			// Clear responses when listen is false
-			setResponses(["", "", "", ""]);
+			setResponses(['', '', '', '']);
 			generate(transcription)
 				.then((r) => {
 					setResponses(r);
 				})
 				.catch((error) => {
-					console.error("Error generating responses:", error);
+					console.error('Error generating responses:', error);
 				});
 		}
 	}, [listen, transcription]);
 
 	async function generate(voiceInput: string): Promise<string[]> {
 		const res = await fetch(`${SERVER_URL}/query`, {
-			method: "POST",
+			method: 'POST',
 			// Assuming the server expects an array of questions
 			body: JSON.stringify({ question: voiceInput }),
 			headers: {
-				"Content-Type": "application/json",
-				"accept": "application/json",
+				'Content-Type': 'application/json',
+				'accept': 'application/json',
 			},
 		});
 
 		const data = await res.json() as string[];
-		console.log("response: ", data);
+		console.log('response: ', data);
 		return data;
 	}
 
 	const speak = () => {
-		setMessages(prevMessages => [...prevMessages, { message: inputText, side: "right" }]);
-		setInputText("");
+		setMessages(prevMessages => [...prevMessages, { message: inputText, side: 'right' }]);
+		setInputText('');
 
 		// Store the socket reference for later use
 		if (!speakSocket) {
-			setSpeakSocket(new WebSocket(WEBSOCKET_URL + "/speak"));
+			setSpeakSocket(new WebSocket(WEBSOCKET_URL + '/speak'));
 		}
 	};
 
 	useEffect(() => {
 		if (speakSocket) {
-			console.log("speakSocket");
+			console.log('speakSocket');
 			speakSocket.onerror = function (event) {
-				console.error("WebSocket error:", event);
-				alert("There was an error connecting to the speech server");
+				console.error('WebSocket error:', event);
+				alert('There was an error connecting to the speech server');
 			};
 
 			speakSocket.onopen = (event) => {
-				console.log("WebSocket connection opened:", event);
+				console.log('WebSocket connection opened:', event);
 
 				// Send the question to the server
 				const message = { question: inputText };
@@ -145,12 +145,12 @@ export function App() {
 			speakSocket.onmessage = (event) => {
 				// Assuming audio data is already in ArrayBuffer format
 				const audioData = event.data as ArrayBuffer;
-				const audioBlob = new Blob([audioData], { type: "audio/wav" });
+				const audioBlob = new Blob([audioData], { type: 'audio/wav' });
 				const audioUrl = URL.createObjectURL(audioBlob);
 
 				setAudioURL(audioUrl);
-				speakSocket.send("ACK");
-				console.log("Audio URL:", audioUrl);
+				speakSocket.send('ACK');
+				console.log('Audio URL:', audioUrl);
 
 				// socket.close();
 			};
@@ -158,13 +158,13 @@ export function App() {
 			speakSocket.onclose = function (event) {
 				// Reset webSocket state to null when connection closes
 				setSpeakSocket(null);
-				setInputText("");
+				setInputText('');
 
 				if (event.wasClean) {
-					console.log("WebSocket closed cleanly:", event);
+					console.log('WebSocket closed cleanly:', event);
 				}
 				else {
-					console.log("WebSocket connection closed unexpectedly:", event);
+					console.log('WebSocket connection closed unexpectedly:', event);
 				}
 			};
 		}

--- a/front-end/src/components/Chat.tsx
+++ b/front-end/src/components/Chat.tsx
@@ -1,10 +1,10 @@
-import { ChatBubble } from "./ChatBubble";
+import { ChatBubble } from './ChatBubble';
 
-import styles from "./Chat.module.css";
+import styles from './Chat.module.css';
 
 export interface Message {
 	message: string;
-	side: "left" | "right";
+	side: 'left' | 'right';
 }
 
 interface Props {

--- a/front-end/src/components/Chat.tsx
+++ b/front-end/src/components/Chat.tsx
@@ -3,15 +3,15 @@ import { ChatBubble } from "./ChatBubble";
 import styles from "./Chat.module.css";
 
 export interface Message {
-    message: string;
-    side: "left" | "right";
+	message: string;
+	side: "left" | "right";
 }
 
 interface Props {
 	messages: Message[];
 }
 
-export function Chat ({ messages }: Props) {
+export function Chat({ messages }: Props) {
 	return (
 		<div className={styles.chat}>
 			<div className={styles.titleBar}>
@@ -19,7 +19,7 @@ export function Chat ({ messages }: Props) {
 			</div>
 			<div className={styles.messagesList}>
 				{messages.map((message, index) => (
-					<ChatBubble key={index} side={message.side} message={message.message}/>
+					<ChatBubble key={index} side={message.side} message={message.message} />
 				))}
 			</div>
 		</div>

--- a/front-end/src/components/ChatBubble.tsx
+++ b/front-end/src/components/ChatBubble.tsx
@@ -1,17 +1,17 @@
-import styles from "./ChatBubble.module.css";
+import styles from './ChatBubble.module.css';
 
 interface Props {
-	side: "left" | "right";
+	side: 'left' | 'right';
 	message: string;
 }
 
 export function ChatBubble({ side, message }: Props) {
 	return (
 		<div
-			className={styles.messageBar + " " + (side === "left" ? styles.messageBar_left : styles.messageBar_right)}
+			className={styles.messageBar + ' ' + (side === 'left' ? styles.messageBar_left : styles.messageBar_right)}
 		>
 			<div
-				className={styles.chatBubble + " " + (side === "left" ? styles.chatBubble_left : styles.chatBubble_right)}
+				className={styles.chatBubble + ' ' + (side === 'left' ? styles.chatBubble_left : styles.chatBubble_right)}
 			>
 				{message}
 			</div>

--- a/front-end/src/components/ChatBubble.tsx
+++ b/front-end/src/components/ChatBubble.tsx
@@ -1,11 +1,11 @@
 import styles from "./ChatBubble.module.css";
 
 interface Props {
-    side: "left" | "right";
-    message: string;
+	side: "left" | "right";
+	message: string;
 }
 
-export function ChatBubble ({ side, message }: Props) {
+export function ChatBubble({ side, message }: Props) {
 	return (
 		<div
 			className={styles.messageBar + " " + (side === "left" ? styles.messageBar_left : styles.messageBar_right)}

--- a/front-end/src/components/InputBar.tsx
+++ b/front-end/src/components/InputBar.tsx
@@ -3,14 +3,14 @@ import pencil from "../assets/pencil.svg";
 import paperAirplane from "../assets/paper-airplane.svg";
 
 interface Props {
-    inputText: string;
-    onInputChange: (newText: string) => void;
-    speak: () => void;
-    audioURL: string | null;
+	inputText: string;
+	onInputChange: (newText: string) => void;
+	speak: () => void;
+	audioURL: string | null;
 }
 
-export function InputBar ({ inputText, onInputChange, speak, audioURL }: Props) {
-	function openKeyboard () {
+export function InputBar({ inputText, onInputChange, speak, audioURL }: Props) {
+	function openKeyboard() {
 		alert("You should probably change this!");
 	}
 

--- a/front-end/src/components/InputBar.tsx
+++ b/front-end/src/components/InputBar.tsx
@@ -1,6 +1,6 @@
-import styles from "./InputBar.module.css";
-import pencil from "../assets/pencil.svg";
-import paperAirplane from "../assets/paper-airplane.svg";
+import styles from './InputBar.module.css';
+import pencil from '../assets/pencil.svg';
+import paperAirplane from '../assets/paper-airplane.svg';
 
 interface Props {
 	inputText: string;
@@ -11,7 +11,7 @@ interface Props {
 
 export function InputBar({ inputText, onInputChange, speak, audioURL }: Props) {
 	function openKeyboard() {
-		alert("You should probably change this!");
+		alert('You should probably change this!');
 	}
 
 	return (

--- a/front-end/src/components/Listen.tsx
+++ b/front-end/src/components/Listen.tsx
@@ -1,6 +1,6 @@
-import VolumeHigh from "../assets/volume-high-solid.svg";
-import VolumeMute from "../assets/volume-xmark-solid.svg";
-import styles from "./Listen.module.css";
+import VolumeHigh from '../assets/volume-high-solid.svg';
+import VolumeMute from '../assets/volume-xmark-solid.svg';
+import styles from './Listen.module.css';
 
 interface Props {
 	listen: boolean;
@@ -14,7 +14,7 @@ export function Listen({ listen, toggleListen }: Props) {
 			onClick={toggleListen}
 		>
 			<img className={styles.volumeIcon} src={listen ? VolumeHigh : VolumeMute} />
-			{`Listen: ${listen ? "On" : "Off"}`}
+			{`Listen: ${listen ? 'On' : 'Off'}`}
 		</div>
 	);
 }

--- a/front-end/src/components/Listen.tsx
+++ b/front-end/src/components/Listen.tsx
@@ -7,14 +7,14 @@ interface Props {
 	toggleListen: () => void;
 }
 
-export function Listen ({ listen, toggleListen }: Props) {
+export function Listen({ listen, toggleListen }: Props) {
 	return (
 		<div
 			className={styles.listenButton}
 			onClick={toggleListen}
 		>
-			<img className={styles.volumeIcon} src={listen ? VolumeHigh : VolumeMute}/>
-			Listen: {listen ? "On" : "Off"}
+			<img className={styles.volumeIcon} src={listen ? VolumeHigh : VolumeMute} />
+			{`Listen: ${listen ? "On" : "Off"}`}
 		</div>
 	);
 }

--- a/front-end/src/components/Responses.tsx
+++ b/front-end/src/components/Responses.tsx
@@ -7,9 +7,7 @@ interface Props {
 	setInputText: Dispatch<SetStateAction<string>>;
 }
 
-
-export function Responses ({ responses, setInputText }: Props) {
-
+export function Responses({ responses, setInputText }: Props) {
 	return (
 		<div className={styles.responses}>
 			<div className={styles.titleBar}>

--- a/front-end/src/components/Responses.tsx
+++ b/front-end/src/components/Responses.tsx
@@ -1,6 +1,6 @@
-import type { Dispatch, SetStateAction } from "react";
+import type { Dispatch, SetStateAction } from 'react';
 
-import styles from "./Responses.module.css";
+import styles from './Responses.module.css';
 
 interface Props {
 	responses: string[];

--- a/front-end/src/index.tsx
+++ b/front-end/src/index.tsx
@@ -1,13 +1,13 @@
-import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
 
-import "./index.css";
-import { App } from "./App.js";
-import { reportWebVitals } from "./reportWebVitals.js";
+import './index.css';
+import { App } from './App.js';
+import { reportWebVitals } from './reportWebVitals.js';
 
 const root = createRoot(
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	document.getElementById("root")!,
+	document.getElementById('root')!,
 );
 root.render(
 	<StrictMode>

--- a/front-end/src/reportWebVitals.test.ts
+++ b/front-end/src/reportWebVitals.test.ts
@@ -30,4 +30,3 @@ describe(basename(import.meta.url), () => {
 		}).not.toThrow();
 	});
 });
-

--- a/front-end/src/reportWebVitals.test.ts
+++ b/front-end/src/reportWebVitals.test.ts
@@ -1,7 +1,7 @@
-import { basename } from "node:path";
-import { describe, expect, test, vi } from "vitest";
+import { basename } from 'node:path';
+import { describe, expect, test, vi } from 'vitest';
 
-import { reportWebVitals } from "./reportWebVitals";
+import { reportWebVitals } from './reportWebVitals';
 
 const mockWebVitals = vi.hoisted(() => ({
 	onCLS: vi.fn(),
@@ -10,10 +10,10 @@ const mockWebVitals = vi.hoisted(() => ({
 	onLCP: vi.fn(),
 	onTTFB: vi.fn(),
 }));
-vi.mock("web-vitals", () => mockWebVitals);
+vi.mock('web-vitals', () => mockWebVitals);
 
 describe(basename(import.meta.url), () => {
-	test("registers onPerfEntry callback web-vitals event handlers", () => {
+	test('registers onPerfEntry callback web-vitals event handlers', () => {
 		const mockOnPerfEntry = vi.fn();
 
 		reportWebVitals(mockOnPerfEntry);
@@ -24,7 +24,7 @@ describe(basename(import.meta.url), () => {
 		expect(mockWebVitals.onTTFB).toHaveBeenCalledWith(mockOnPerfEntry);
 	});
 
-	test("does not throw an error when onPerfEntry is not provided", () => {
+	test('does not throw an error when onPerfEntry is not provided', () => {
 		expect(() => {
 			reportWebVitals();
 		}).not.toThrow();

--- a/front-end/src/reportWebVitals.ts
+++ b/front-end/src/reportWebVitals.ts
@@ -1,7 +1,7 @@
 import { onCLS, onFID, onFCP, onLCP, onTTFB } from "web-vitals";
 import type { ReportCallback } from "web-vitals";
 
-export function reportWebVitals (onPerfEntry?: ReportCallback) {
+export function reportWebVitals(onPerfEntry?: ReportCallback) {
 	if (onPerfEntry && onPerfEntry instanceof Function) {
 		onCLS(onPerfEntry);
 		onFID(onPerfEntry);

--- a/front-end/src/reportWebVitals.ts
+++ b/front-end/src/reportWebVitals.ts
@@ -1,5 +1,5 @@
-import { onCLS, onFID, onFCP, onLCP, onTTFB } from "web-vitals";
-import type { ReportCallback } from "web-vitals";
+import { onCLS, onFID, onFCP, onLCP, onTTFB } from 'web-vitals';
+import type { ReportCallback } from 'web-vitals';
 
 export function reportWebVitals(onPerfEntry?: ReportCallback) {
 	if (onPerfEntry && onPerfEntry instanceof Function) {

--- a/front-end/tsconfig.json
+++ b/front-end/tsconfig.json
@@ -1,13 +1,12 @@
 {
 	"include": ["src"],
 	"compilerOptions": {
-		"target": "ES2020",
+		"target": "ESNext",
 		"module": "ESNext",
 		"moduleResolution": "bundler",
-		"lib": ["ES2020", "DOM", "DOM.Iterable"],	
-		"strict": true,
 		"jsx": "react-jsx",
-		"noEmit": true,
+		"strict": true,
 		"verbatimModuleSyntax": true,
+		"noEmit": true,
 	},
 }

--- a/front-end/vite.config.ts
+++ b/front-end/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react-swc";
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
A bunch of ESLint rules were recently deprecated and moved over to a new `@stylistic/eslint-plugin` package. I also recently learned about how to configure linting for JSX files.

## Added

- ESLint configuration that uses the new `@stylistic` package
- JSX linting

## Changed

- Some ESLint rules to match recommended settings (such as single-quotes, no spaces before function parentheses, etc)
- All files to conform with new lint rules
- Updated all ESLint-related dependencies to latest versions